### PR TITLE
Remove `set_magic_quotes_runtime()`

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,4 +1,4 @@
-=== Plugin Name ===
+=== RSS Importer ===
 Contributors: wordpressdotorg
 Tags: importer, rss
 Requires at least: 3.0
@@ -24,6 +24,9 @@ Import posts from an RSS feed.
 == Screenshots ==
 
 == Changelog ==
+
+= 0.3 =
+ * Removed `set_magic_quotes_runtime()` for PHP 7 compatibility.
 
 = 0.2 =
 * Update compat

--- a/rss-importer.php
+++ b/rss-importer.php
@@ -69,7 +69,6 @@ class RSS_Import extends WP_Importer {
 	function get_posts() {
 		global $wpdb;
 
-		set_magic_quotes_runtime(0);
 		$datalines = file($this->file); // Read the file into an array
 		$importdata = implode('', $datalines); // squish it
 		$importdata = str_replace(array ("\r\n", "\r"), "\n", $importdata);


### PR DESCRIPTION
This PR is a copy of #1 which I made unmergeable, taking the direction of core and simply removing the call to this function.

WordPress sets up the environment this plugin operates in, removing this call should have no impact.

See #1.
Fixes #3.
Fixes https://core.trac.wordpress.org/ticket/52074