### PR TITLE
Add support for WordPress 6.1

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: wordpressdotorg
 Tags: importer, rss
 Requires at least: 3.0
-Tested up to: 4.7
-Stable tag: trunk
+Tested up to: 6.1
+Stable tag: 0.3
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -27,6 +27,7 @@ Import posts from an RSS feed.
 
 = 0.3 =
 * Removed `set_magic_quotes_runtime()` for PHP 7 compatibility.
+* Add support for WordPress 6.1
 
 = 0.2 =
 * Update compat

--- a/readme.txt
+++ b/readme.txt
@@ -26,7 +26,7 @@ Import posts from an RSS feed.
 == Changelog ==
 
 = 0.3 =
- * Removed `set_magic_quotes_runtime()` for PHP 7 compatibility.
+* Removed `set_magic_quotes_runtime()` for PHP 7 compatibility.
 
 = 0.2 =
 * Update compat

--- a/rss-importer.php
+++ b/rss-importer.php
@@ -5,8 +5,8 @@ Plugin URI: http://wordpress.org/extend/plugins/rss-importer/
 Description: Import posts from an RSS feed.
 Author: wordpressdotorg
 Author URI: http://wordpress.org/
-Version: 0.2
-Stable tag: 0.2
+Version: 0.3
+Stable tag: 0.3
 License: GPL version 2 or later - http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 Text Domain: rss-importer
 */

--- a/rss-importer.php
+++ b/rss-importer.php
@@ -116,7 +116,11 @@ class RSS_Import extends WP_Importer {
 
 			preg_match('|<content:encoded>(.*?)</content:encoded>|is', $post, $post_content);
 
-			$post_content = str_replace(array ('<![CDATA[', ']]>'), '', esc_sql(trim($post_content[1])));
+			if (count($post_content) > 1) {
+				$post_content = str_replace(array ('<![CDATA[', ']]>'), '', esc_sql(trim($post_content[1])));
+			} else {
+				$post_content = null;
+			}
 
 			if (!$post_content) {
 				// This is for feeds that put content in description

--- a/rss-importer.php
+++ b/rss-importer.php
@@ -82,7 +82,7 @@ class RSS_Import extends WP_Importer {
 		$index = 0;
 		foreach ($this->posts as $post) {
 			preg_match('|<title>(.*?)</title>|is', $post, $post_title);
-			$post_title = str_replace(array('<![CDATA[', ']]>'), '', esc_sql( trim($post_title[1]) ));
+			$post_title = str_replace(array('<![CDATA[', ']]>'), '', esc_sql( trim($post_title[1]) ) );
 
 			preg_match('|<pubdate>(.*?)</pubdate>|is', $post, $post_date_gmt);
 
@@ -114,15 +114,16 @@ class RSS_Import extends WP_Importer {
 			}
 
 			preg_match('|<guid.*?>(.*?)</guid>|is', $post, $guid);
-			if ($guid)
-				$guid = esc_sql(trim($guid[1]));
-			else
+			if ( $guid ) {
+				$guid = esc_sql( trim( $guid[1] ) );
+			} else {
 				$guid = '';
+			}
 
 			preg_match('|<content:encoded>(.*?)</content:encoded>|is', $post, $post_content);
 
-			if (count($post_content) > 1) {
-				$post_content = str_replace(array ('<![CDATA[', ']]>'), '', esc_sql(trim($post_content[1])));
+			if ( count( $post_content ) > 1 ) {
+				$post_content = str_replace( array( '<![CDATA[', ']]>'), '', esc_sql( trim( $post_content[1] ) ) );
 			} else {
 				$post_content = null;
 			}

--- a/rss-importer.php
+++ b/rss-importer.php
@@ -77,7 +77,7 @@ class RSS_Import extends WP_Importer {
 		$index = 0;
 		foreach ($this->posts as $post) {
 			preg_match('|<title>(.*?)</title>|is', $post, $post_title);
-			$post_title = str_replace(array('<![CDATA[', ']]>'), '', $wpdb->escape( trim($post_title[1]) ));
+			$post_title = str_replace(array('<![CDATA[', ']]>'), '', esc_sql( trim($post_title[1]) ));
 
 			preg_match('|<pubdate>(.*?)</pubdate>|is', $post, $post_date_gmt);
 
@@ -104,23 +104,24 @@ class RSS_Import extends WP_Importer {
 
 			$cat_index = 0;
 			foreach ($categories as $category) {
-				$categories[$cat_index] = $wpdb->escape( html_entity_decode( $category ) );
+				$categories[$cat_index] = esc_sql( html_entity_decode( $category ) );
 				$cat_index++;
 			}
 
 			preg_match('|<guid.*?>(.*?)</guid>|is', $post, $guid);
 			if ($guid)
-				$guid = $wpdb->escape(trim($guid[1]));
+				$guid = esc_sql(trim($guid[1]));
 			else
 				$guid = '';
 
 			preg_match('|<content:encoded>(.*?)</content:encoded>|is', $post, $post_content);
-			$post_content = str_replace(array ('<![CDATA[', ']]>'), '', $wpdb->escape(trim($post_content[1])));
+
+			$post_content = str_replace(array ('<![CDATA[', ']]>'), '', esc_sql(trim($post_content[1])));
 
 			if (!$post_content) {
 				// This is for feeds that put content in description
 				preg_match('|<description>(.*?)</description>|is', $post, $post_content);
-				$post_content = $wpdb->escape( html_entity_decode( trim( $post_content[1] ) ) );
+				$post_content = esc_sql( html_entity_decode( trim( $post_content[1] ) ) );
 			}
 
 			// Clean up content

--- a/rss-importer.php
+++ b/rss-importer.php
@@ -48,7 +48,7 @@ class RSS_Import extends WP_Importer {
 	function header() {
 		echo '<div class="wrap">';
 
-		if ( version_compare(get_bloginfo('version'), '3.8.0', '<') ) {
+		if ( version_compare( get_bloginfo( 'version' ), '3.8.0', '<' ) ) {
 			screen_icon();
 		}
 

--- a/rss-importer.php
+++ b/rss-importer.php
@@ -10,9 +10,9 @@ Stable tag: 0.2
 License: GPL version 2 or later - http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 Text Domain: rss-importer
 */
-
-if ( !defined('WP_LOAD_IMPORTERS') )
+if ( !defined('WP_LOAD_IMPORTERS') ) {
 	return;
+}
 
 // Load Importer API
 require_once ABSPATH . 'wp-admin/includes/import.php';
@@ -47,6 +47,11 @@ class RSS_Import extends WP_Importer {
 
 	function header() {
 		echo '<div class="wrap">';
+
+		if ( version_compare(get_bloginfo('version'), '3.8.0', '<') ) {
+			screen_icon();
+		}
+
 		echo '<h2>'.__('Import RSS', 'rss-importer').'</h2>';
 	}
 

--- a/rss-importer.php
+++ b/rss-importer.php
@@ -47,7 +47,6 @@ class RSS_Import extends WP_Importer {
 
 	function header() {
 		echo '<div class="wrap">';
-		screen_icon();
 		echo '<h2>'.__('Import RSS', 'rss-importer').'</h2>';
 	}
 


### PR DESCRIPTION
This PR fixes the plugins and adds support for WordPress 6.1 and upgrades the plugin to 0.3.

- Tested with WordPress `6.1`
- Tested with PHP `7.4.33`
- The `screen_icon` function is now deprecated. Added a check for WordPress 3.8.0
- The `$wpdb->escape` function is now deprecated. Changed to `esc_sql`

How to test:
1. Clone the plugin
2. Spin a new docker image[^1]
3. Substitute `YOUR_FOLDER` with the path of the cloned plugin
4. Go to `http://localhost/wp-admin/plugins.php` and activate **RSS Importer**
5. Open `http://localhost/wp-admin/admin.php?import=rss`
6. Open a sample RSS. The plugin must load correctly and no errors displayed

[^1]: `docker-compose.yml` file
```yaml
services:
  db:
    image: mariadb:latest
    command: '--default-authentication-plugin=mysql_native_password'
    volumes:
      - db_data:/var/lib/mysql
    restart: always
    environment:
      - MYSQL_ROOT_PASSWORD=somewordpress
      - MYSQL_DATABASE=wordpress
      - MYSQL_USER=wordpress
      - MYSQL_PASSWORD=wordpress
    expose:
      - 3306
      - 33060
  wordpress:
    image: wordpress:latest
    volumes:
      - wp_data:/var/www/html
      - YOUR_FOLDER:/var/www/html/wp-content/plugins/rss-importer
    ports:
      - 80:80
    restart: always
    environment:
      - WORDPRESS_DB_HOST=db
      - WORDPRESS_DB_USER=wordpress
      - WORDPRESS_DB_PASSWORD=wordpress
      - WORDPRESS_DB_NAME=wordpress
      - WORDPRESS_DEBUG=1
volumes:
  db_data:
  wp_data:
```
