### PR TITLE
Testing the plugin up to WordPress 6.2

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: wordpressdotorg
 Tags: importer, rss
 Requires at least: 3.0
-Tested up to: 6.1
-Stable tag: 0.3
+Tested up to: 6.2
+Stable tag: 0.3.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -24,6 +24,9 @@ Import posts from an RSS feed.
 == Screenshots ==
 
 == Changelog ==
+
+= 0.3.1 =
+* Testing the plugin up to WordPress 6.2
 
 = 0.3 =
 * Removed `set_magic_quotes_runtime()` for PHP 7 compatibility.

--- a/rss-importer.php
+++ b/rss-importer.php
@@ -5,8 +5,8 @@ Plugin URI: http://wordpress.org/extend/plugins/rss-importer/
 Description: Import posts from an RSS feed.
 Author: wordpressdotorg
 Author URI: http://wordpress.org/
-Version: 0.3
-Stable tag: 0.3
+Version: 0.3.1
+Stable tag: 0.3.1
 License: GPL version 2 or later - http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 Text Domain: rss-importer
 */


### PR DESCRIPTION
This PR adds support for WordPress 6.2 and upgrades the plugin to 0.3.1.

Tested with WordPress 6.2
Tested with PHP 5.6, PHP 7.4, PHP 8.0
How to test:

- Clone the plugin under your working directory
- Using `wp-env` to test, if you haven't installed it, please visit [wp-env](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-env/#quick-tldr-instructions) for instructions
- It'll be easier if you have a `.wp-env.json` file at the root folder. For example, if your root folder is `oss-importer` and you can clone the plugin under this folder. Create `.wp.-env.json` file, you can change PHP version to the one you want to test with.
```
{
  "phpVersion": "5.6",
  "plugins": ["./rss-importer"]
}
```
- Run `wp-env start` to spin up the WordPress
- Navigate to `http://localhost:8888/wp-admin/admin.php?import=rss` and perform an import
- Import the content; it can take a while if you have a lot of content. If the script timeout, you need to set_time_limit to a higher value
- Check and see if the import works fine without errors