### PR TITLE
Test plugin for WordPress 6.3

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: wordpressdotorg
 Tags: importer, rss
 Requires at least: 3.0
 Tested up to: 6.3
-Stable tag: 0.3.2
+Stable tag: 0.3.1
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -24,9 +24,6 @@ Import posts from an RSS feed.
 == Screenshots ==
 
 == Changelog ==
-
-= 0.3.2 =
-* Testing the plugin up to WordPress 6.3
 
 = 0.3.1 =
 * Testing the plugin up to WordPress 6.2

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: wordpressdotorg
 Tags: importer, rss
 Requires at least: 3.0
-Tested up to: 6.2
-Stable tag: 0.3.1
+Tested up to: 6.3
+Stable tag: 0.3.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -24,6 +24,9 @@ Import posts from an RSS feed.
 == Screenshots ==
 
 == Changelog ==
+
+= 0.3.2 =
+* Testing the plugin up to WordPress 6.3
 
 = 0.3.1 =
 * Testing the plugin up to WordPress 6.2

--- a/rss-importer.php
+++ b/rss-importer.php
@@ -5,8 +5,8 @@ Plugin URI: https://wordpress.org/extend/plugins/rss-importer/
 Description: Import posts from an RSS feed.
 Author: wordpressdotorg
 Author URI: https://wordpress.org/
-Version: 0.3.1
-Stable tag: 0.3.1
+Version: 0.3.2
+Stable tag: 0.3.2
 License: GPL version 2 or later - https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 Text Domain: rss-importer
 */

--- a/rss-importer.php
+++ b/rss-importer.php
@@ -5,8 +5,8 @@ Plugin URI: https://wordpress.org/extend/plugins/rss-importer/
 Description: Import posts from an RSS feed.
 Author: wordpressdotorg
 Author URI: https://wordpress.org/
-Version: 0.3.2
-Stable tag: 0.3.2
+Version: 0.3.1
+Stable tag: 0.3.1
 License: GPL version 2 or later - https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 Text Domain: rss-importer
 */


### PR DESCRIPTION
In this PR, we test the plugin for WordPress 6.3.

## How to test

1. Clone this PR
2. Using `wp-env` run an instance. The minimum PHP version is 7.0 because WordPress 6.3 [dropped support for PHP 5](https://make.wordpress.org/core/2023/07/05/dropping-support-for-php-5/).
3. Go to `http://localhost:8888/wp-admin/admin.php?import=rss` and perform an import.
4. Check if the content has been imported and no errors are being generated.